### PR TITLE
Upgrade pip to 20.0.2 in openvino-mo image

### DIFF
--- a/nauta-containers/openvino-mo/Dockerfile
+++ b/nauta-containers/openvino-mo/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install -y python3-pip python3-venv libgfortran3
 COPY --from=build /root/model-optimizer /root/model-optimizer
 
 COPY requirements.txt nauta-requirements.txt
+RUN pip3 install --upgrade pip==20.0.2
 RUN pip3 install -r nauta-requirements.txt
 
 WORKDIR /root/model-optimizer


### PR DESCRIPTION
Fixing a problem with tensorflow/tensorboard installation by bumping pip version to 20.0.2 (from ancient 9.0.1 that was used till now).